### PR TITLE
Use embulkPluginRuntime.lockfile for locking dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ out:
 ### Run examples
 
 ```shell
-$ ./gradlew gem
+$ ./gradlew gem --write-locks
 $ embulk bundle install --gemfile ./example/Gemfile
 $ embulk run example/config.yml -I build/gemContents/lib -b example
 ```
@@ -98,7 +98,7 @@ $ ./gradlew spotlessApply
 ### Build
 
 ```shell
-$ ./gradlew gem  # -t to watch change of files and rebuild continuously
+$ ./gradlew gem --write-locks  # -t to watch change of files and rebuild continuously
 ```
 
 ### Release a new gem

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,0 +1,4 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.scala-lang:scala-library:2.13.1


### PR DESCRIPTION
- [Enhancement] Use embulkPluginRuntime.lockfile for locking dependencies.