### PR TITLE
Support embulk preview execution

### DIFF
--- a/src/main/scala/pro/civitaspo/embulk/input/union/ThreadNameContext.scala
+++ b/src/main/scala/pro/civitaspo/embulk/input/union/ThreadNameContext.scala
@@ -11,6 +11,8 @@ object ThreadNameContext {
   private def trimThreadId(str: String): String =
     str.replaceFirst("^\\d{4}:", "")
   private def currentThreadName: String = Thread.currentThread.getName
+
+  def isPreviewExecution: Boolean = currentThreadName.contains("preview")
 }
 
 case class ThreadNameContext private (

--- a/src/main/scala/pro/civitaspo/embulk/input/union/UnionInputPlugin.scala
+++ b/src/main/scala/pro/civitaspo/embulk/input/union/UnionInputPlugin.scala
@@ -97,8 +97,14 @@ class UnionInputPlugin extends InputPlugin {
   ): TaskReport = {
     val task: PluginTask = taskSource.loadTask(classOf[PluginTask])
     val loaderTask: BreakinBulkLoader.Task = task.getUnion(taskIndex)
-    try BreakinBulkLoader(loaderTask, taskIndex).run(schema, output)
-    finally output.finish()
+
+    // NOTE: `embulk preview` shows the below error when output.finish() is executed.
+    // 2022-03-07 14:48:01.939 +0000 [ERROR] (0001:preview): PreviewResult recreation will cause a bug. The plugin must call PageOutput#finish() only once.
+    if (ThreadNameContext.isPreviewExecution)
+      BreakinBulkLoader(loaderTask, taskIndex).run(schema, output)
+    else
+      try BreakinBulkLoader(loaderTask, taskIndex).run(schema, output)
+      finally output.finish()
     Exec.newTaskReport()
   }
   override def guess(config: ConfigSource): ConfigDiff =

--- a/src/main/scala/pro/civitaspo/embulk/input/union/Utils.scala
+++ b/src/main/scala/pro/civitaspo/embulk/input/union/Utils.scala
@@ -5,11 +5,34 @@ import java.security.MessageDigest
 import java.util.UUID
 
 object Utils {
+  import implicits._
+
   def genTransactionId(): String = {
     val uuid: UUID = UUID.randomUUID()
     val md: MessageDigest = MessageDigest.getInstance("SHA1")
     val sha1: String =
       md.digest(uuid.toString.getBytes(UTF_8)).map("%02x".format(_)).mkString
     sha1.take(7)
+  }
+
+  def recursiveExceptionMatch(ex: Throwable, klass: Class[_]): Option[_] = {
+    Option(ex) match {
+      case None                               => None
+      case Some(ex1) if ex1.getClass == klass => Some(ex1)
+      case Some(ex1) =>
+        Option(ex1.getSuppressed) match {
+          case Some(supp)
+              if supp.exists(recursiveExceptionMatch(_, klass).isDefined) =>
+            supp
+              .map(recursiveExceptionMatch(_, klass))
+              .find(_.isDefined)
+              .flatten
+          case _ =>
+            Option(ex1.getCause) match {
+              case Some(cause) => recursiveExceptionMatch(cause, klass)
+              case _           => None
+            }
+        }
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: civitaspo <civitaspo@gmail.com>

```
❯ docker run -it --rm -v $(pwd):/work -w /work embulk-docker preview ./example/config.yml -Ibuild/gemContents/lib -bexample
2022-03-07 16:57:05.825 +0000: Embulk v0.9.24
2022-03-07 16:57:06.290 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2022-03-07 16:57:07.456 +0000 [INFO] (main): BUNDLE_GEMFILE is being set: "/work/example/Gemfile"
2022-03-07 16:57:07.456 +0000 [INFO] (main): Gem's home and path are being cleared.
io/console on JRuby shells out to stty for most operations
2022-03-07 16:57:08.525 +0000 [INFO] (main): Started Embulk v0.9.24
2022-03-07 16:57:08.621 +0000 [INFO] (0001:preview): Loaded plugin embulk/input/union from a load path
2022-03-07 16:57:09.006 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#transaction): Listing local files at directory './example/data' filtering filename by prefix ''
2022-03-07 16:57:09.007 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2022-03-07 16:57:09.018 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#transaction): Loading files [./example/data/data00.tsv, ./example/data/data01.tsv, ./example/data/data02.tsv, ./example/data/data03.tsv, ./example/data/data04.tsv]
2022-03-07 16:57:09.107 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#transaction): Loaded plugin embulk-filter-column (0.8.1)
2022-03-07 16:57:09.148 +0000 [INFO] (0001:transaction[e6e85dc]:union[1]:example:#transaction): Listing local files at directory './example/data' filtering filename by prefix ''
2022-03-07 16:57:09.148 +0000 [INFO] (0001:transaction[e6e85dc]:union[1]:example:#transaction): "follow_symlinks" is set false. Note that symbolic links to directories are skipped.
2022-03-07 16:57:09.148 +0000 [INFO] (0001:transaction[e6e85dc]:union[1]:example:#transaction): Loading files [./example/data/data00.tsv, ./example/data/data01.tsv, ./example/data/data02.tsv, ./example/data/data03.tsv, ./example/data/data04.tsv]
2022-03-07 16:57:09.162 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#run): Using local thread executor with max_threads=5 / tasks=5
2022-03-07 16:57:09.189 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#run): {done:  0 / 5, running: 3}
2022-03-07 16:57:09.254 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#run): {done:  2 / 5, running: 3}
2022-03-07 16:57:09.258 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#run): {done:  5 / 5, running: 0}
2022-03-07 16:57:09.258 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#run): {done:  5 / 5, running: 0}
2022-03-07 16:57:09.259 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#run): {done:  5 / 5, running: 0}
2022-03-07 16:57:09.259 +0000 [INFO] (0001:transaction[e6e85dc]:union[0]:in[file].filters[column]:#run): {done:  5 / 5, running: 0}
+---------+--------------------+-------------+-------------------------+------------------+-------------------+
| id:long | description:string | name:string |             t:timestamp |     payload:json | group_name:string |
+---------+--------------------+-------------+-------------------------+------------------+-------------------+
|       0 |         c20ef94602 |  c212c89f91 | 2017-10-23 18:54:35 UTC | {"a":0,"b":"99"} |           group01 |
|       1 |         330a9fc33a |  e25b33b616 | 2017-10-22 10:53:31 UTC | {"a":1,"b":"a9"} |           group01 |
|       2 |         707b3b7588 |  90823c6a1f | 2017-10-23 14:42:43 UTC | {"a":2,"b":"96"} |           group01 |
|       3 |         8d8288e66f |             | 2017-10-21 21:12:13 UTC | {"a":3,"b":"86"} |           group01 |
|       4 |         c54d8b6481 |  e56a40571c | 2017-10-22 19:59:16 UTC | {"a":4,"b":"d2"} |           group01 |
|       0 |         c20ef94602 |  c212c89f91 | 2017-10-23 18:54:35 UTC | {"a":0,"b":"99"} |           group01 |
|       1 |         330a9fc33a |  e25b33b616 | 2017-10-22 10:53:31 UTC | {"a":1,"b":"a9"} |           group01 |
|       2 |         707b3b7588 |  90823c6a1f | 2017-10-23 14:42:43 UTC | {"a":2,"b":"96"} |           group01 |
|       3 |         8d8288e66f |             | 2017-10-21 21:12:13 UTC | {"a":3,"b":"86"} |           group01 |
|       4 |         c54d8b6481 |  e56a40571c | 2017-10-22 19:59:16 UTC | {"a":4,"b":"d2"} |           group01 |
|       0 |         c20ef94602 |  c212c89f91 | 2017-10-23 18:54:35 UTC | {"a":0,"b":"99"} |           group01 |
|       1 |         330a9fc33a |  e25b33b616 | 2017-10-22 10:53:31 UTC | {"a":1,"b":"a9"} |           group01 |
|       2 |         707b3b7588 |  90823c6a1f | 2017-10-23 14:42:43 UTC | {"a":2,"b":"96"} |           group01 |
|       3 |         8d8288e66f |             | 2017-10-21 21:12:13 UTC | {"a":3,"b":"86"} |           group01 |
|       4 |         c54d8b6481 |  e56a40571c | 2017-10-22 19:59:16 UTC | {"a":4,"b":"d2"} |           group01 |
+---------+--------------------+-------------+-------------------------+------------------+-------------------+
```