### PR TITLE
Rel/0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.3 (2022-03-20)
+==================
+
+* [#10](https://github.com/civitaspo/embulk-input-union/pull/10) Avoid the error `org.embulk.exec.NoSampleException: No input records to preview`.
+
 0.0.2 (2022-03-08)
 ==================
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "pro.civitaspo"
-version = "0.0.2"
+version = "0.0.3"
 description = "An input plugin for Embulk (https://github.com/embulk/embulk/) that" +
     " unions all data loaded by your defined embulk input & filters plugin configuration."
 


### PR DESCRIPTION
* [#10](https://github.com/civitaspo/embulk-input-union/pull/10) Avoid the error `org.embulk.exec.NoSampleException: No input records to preview`.