### PR TITLE
Rel/0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.0.4 (2022-03-24)
+==================
+
+* [#11](https://github.com/civitaspo/embulk-input-union/pull/11) Fix so that `embulk preview` can be executed normally even if Filter Plugin is used.
+
 0.0.3 (2022-03-20)
 ==================
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "pro.civitaspo"
-version = "0.0.3"
+version = "0.0.4"
 description = "An input plugin for Embulk (https://github.com/embulk/embulk/) that" +
     " unions all data loaded by your defined embulk input & filters plugin configuration."
 


### PR DESCRIPTION
* [#11](https://github.com/civitaspo/embulk-input-union/pull/11) Fix so that `embulk preview` can be executed normally even if Filter Plugin is used.